### PR TITLE
add missing 'main' property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "rimraf dist && rollup -c rollup.config.js",
+    "build": "npx rimraf dist && npx rollup -c rollup.config.js",
     "test": "vitest run",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "postinstall": "npm run build"
   },
   "peerDependencies": {
     "vite": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vite-plugin-html-resolve-alias",
+  "main": "dist/index.js",
   "type": "module",
   "version": "2.0.1",
   "description": "A vite plugin that can use aliases in html content.",


### PR DESCRIPTION
This fixes the following error occurring in my project when I run the build command:
```
[plugin: externalize-deps] Failed to resolve entry for package "vite-plugin-html-resolve-alias".
The package may have incorrect main/module/exports specified in its package.json.
```